### PR TITLE
[SISCAP-56] Projetos - Cadastro - Reorganizar posicionamento dos botões de ação do formulário

### DIFF
--- a/src/app/pages/projects/form/project-form.component.html
+++ b/src/app/pages/projects/form/project-form.component.html
@@ -302,7 +302,7 @@
         </div>
 
         <div class="row mt-2">
-          <div class="col d-flex justify-content-center" id="interactbtns">
+          <div class="col d-flex flex-row-reverse" id="interactbtns">
             <button
               type="button"
               class="btn btn-primary p-2 px-4 mx-1"


### PR DESCRIPTION
Botão ‘Cancelar’ vem antes de ‘Cadastrar’/'Atualizar'. Grupo de botões fica na parte inferior direita do formulário