### PR TITLE
[SISCAP-63] Breadcrumb - Alterar layout/comportamento do componente

### DIFF
--- a/src/app/components/breadcrumb/breadcrumb.component.css
+++ b/src/app/components/breadcrumb/breadcrumb.component.css
@@ -1,20 +1,12 @@
-* {
-  margin: 0;
-  padding: 0;
-}
-
 nav {
   --bs-breadcrumb-divider: ">";
 }
 
-.button-title-area {
-  max-width: 10%;
+/* Equivalente á aplicar px-2 py-1 em todos os botões do componente */
+button {
+  padding: 0.25rem 0.5rem;
 }
 
-.breadcrumb-nav-area {
-  max-width: 90%;
-}
-
-/* h3 {
+h3 {
   color: rgba(16, 127, 207, 1);
-} */
+}

--- a/src/app/components/breadcrumb/breadcrumb.component.html
+++ b/src/app/components/breadcrumb/breadcrumb.component.html
@@ -1,21 +1,68 @@
-<div class="row h-100 p-1 d-flex flex-column">
-  <div class="col my-2">
-    <nav>
-      <ol class="breadcrumb align-items-center">
-        <button class="btn btn-primary mx-1 px-2 py-1" (click)="navigateBreadcrumb('home')">
-          <i class="fa-solid fa-house"></i>
-        </button>
-
-        <li
-          *ngFor="let path of this.breadcrumbNav"
-          class="breadcrumb-item mx-1"
-        >
-          <a class="pointer" (click)="navigateBreadcrumb(path)">{{
-            path | breadcrumbnavlink
-          }}</a>
-        </li>
+<div class="row g-0 mx-2 px-2">
+  <div class="breadcrumb-nav">
+    <nav [ngClass]="{ invisible: breadcrumbNav.length <= 1 }">
+      <ol class="breadcrumb m-0 pb-1">
+        <ng-container *ngFor="let path of breadcrumbNav">
+          <ng-container
+            *ngIf="path != currentPage"
+            [ngTemplateOutlet]="navLink"
+            [ngTemplateOutletContext]="{ path: path }"
+          ></ng-container>
+          <ng-container
+            *ngIf="path == currentPage"
+            [ngTemplateOutlet]="disabledLink"
+            [ngTemplateOutletContext]="{ path: path }"
+          ></ng-container>
+        </ng-container>
       </ol>
     </nav>
-    <h3 class="ms-1 my-2">{{ this.currentPage | breadcrumbnavlink }}</h3>
+  </div>
+
+  <div class="home-pagetitle-section col">
+    <div class="d-flex flex-row">
+      <button class="btn btn-primary" (click)="navigateBreadcrumb('home')">
+        <i class="fa-solid fa-house"></i>
+      </button>
+      <h3 class="px-2 m-0">{{ currentPage | breadcrumbnavlink }}</h3>
+    </div>
+  </div>
+
+  <div class="new-navbuttons-section col">
+    <div class="d-flex flex-row-reverse">
+      <button class="btn btn-primary" (click)="goForward()">
+        <i class="fa-solid fa-share"></i>
+      </button>
+
+      <button class="btn btn-primary mx-1" (click)="goBack()">
+        <i class="fa-solid fa-reply"></i>
+      </button>
+
+      <ng-container
+        *ngIf="mainChildPaths.includes(currentPage)"
+        [ngTemplateOutlet]="newButton"
+        [ngTemplateOutletContext]="{ path: currentPage }"
+      ></ng-container>
+    </div>
   </div>
 </div>
+
+<!-- Link do breadcrumb 'navegável' -->
+<ng-template #navLink let-path="path">
+  <li class="breadcrumb-item">
+    <a class="link-primary pointer" (click)="navigateBreadcrumb(path)">
+      {{ path | breadcrumbnavlink }}
+    </a>
+  </li>
+</ng-template>
+
+<!-- Link do breadcrumb 'desabilitado' (quando o usuário estiver na página do link) -->
+<ng-template #disabledLink let-path="path">
+  <li class="breadcrumb-item active">{{ path | breadcrumbnavlink }}</li>
+</ng-template>
+
+<!-- Botão de criar um novo dado (ex.: Projetos -> Novo Projeto) -->
+<ng-template #newButton let-path="path">
+  <button class="btn btn-primary me-2" (click)="navigateBreadcrumbNew(path)">
+    {{ path + "create" | breadcrumbnavlink }}
+  </button>
+</ng-template>

--- a/src/app/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/components/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { EventType, NavigationEnd, Router } from '@angular/router';
+
 import { filter } from 'rxjs';
 
 @Component({
@@ -9,6 +10,9 @@ import { filter } from 'rxjs';
   styleUrl: './breadcrumb.component.css',
 })
 export class BreadcrumbComponent {
+  public exclusionList: Array<string> = ['', 'home', 'form']; // Lista de caminhos á serem ignorados (ex.: 'main' e 'form' redirecionam para 'home')
+  public mainChildPaths: Array<string> = ['projects']; // Lista de caminhos "principais" da aplicação (ex.: 'projects', 'programs', etc.)
+
   public breadcrumbNav: Array<string> = [];
   public currentPage: string = '';
 
@@ -21,23 +25,124 @@ export class BreadcrumbComponent {
         })
       )
       .subscribe((next) => {
-        const urlPaths = next['urlAfterRedirects'].split('/').filter((path) => {
-          return path != '' && path != 'main';
-        });
-        this.breadcrumbNav = urlPaths;
-        this.currentPage = this.breadcrumbNav.pop()!;
+        const urlPaths = this.getUrlPaths(next['urlAfterRedirects']);
+        const treatedUrlPaths = this.treatUrlPaths(urlPaths);
+
+        this.breadcrumbNav = treatedUrlPaths;
+        this.currentPage = this.breadcrumbNav.at(
+          this.breadcrumbNav.length - 1
+        )!;
       });
   }
 
-  navigateBreadcrumb(path: string) {
+  /**
+   * Transforma a URL em um array de strings.
+   *
+   * O método `value.map()` retorna o caminho da URL removendo os queryParams (caractere '?') se existirem.
+   *
+   * O método `value.filter()` remove os caminhos contidos na lista de exclusão.
+   *
+   * @param value - A URL em formato de string.
+   * @returns Um array de strings contendo os caminhos da URL.
+   */
+  private getUrlPaths(value: string): string[] {
+    return value
+      .split('/')
+      .map((path) => {
+        return path.includes('?') ? path.substring(0, path.indexOf('?')) : path;
+      })
+      .filter((path) => !this.exclusionList.includes(path));
+  }
+
+  /**
+   * Trata o array dos caminhos da URL para utilizar no pipe do breadcrumb.
+   *
+   * O modo do fomulario (ex: 'create') é concatenado com o caminho anterior, á fim de alimentar o pipe de breadcrumb.
+   *
+   *
+   * @example
+   * ```ts
+   * value = ['main', 'projects', 'create'] // 'create' está atrelado á 'projects' ('form' foi filtrado)
+   * const treatedUrlPaths = this.treatUrlPaths(value) // resultado: ['main', 'projects', 'projectscreate']
+   *
+   * // Dentro do breadcrumbnavlinkPipe
+   * ...
+   * switch(value) {
+   * ...
+   *  case 'projects':
+   *    transformedValue = 'Projetos'
+   *    break;
+   *
+   *  // Errado: 'create' pode ter sido utilizado como o modo do formulário de outra página como 'programs'
+   *  case 'create':
+   *    transformedValue = 'Novo Projeto'
+   *    break;
+   *
+   *  case 'create':
+   *    transformedValue = 'Novo Programa'
+   *    break;
+   *
+   *  // Correto: O valor transformado é retornado de acordo com a página que form/create foi chamado
+   *  case 'projectscreate':
+   *    transformedValue = 'Novo Projeto'
+   *    break;
+   *
+   *  case 'programscreate':
+   *    transformedValue = 'Novo Programa'
+   *    break;
+   * }
+   * ...
+   *
+   * ```
+   *
+   * @param value - O array de strings contendo os caminhos da URL.
+   * @returns O array de strings contendo os caminhos da URL tratados para alimentar o `breadcrumbnavlinkPipe`.
+   */
+  private treatUrlPaths(value: string[]): string[] {
+    const pathCandidates = ['create', 'edit', 'details'];
+    return value.map((path) => {
+      const previousPath = value.at(value.indexOf(path) - 1) ?? path;
+      return pathCandidates.includes(path)
+        ? this.mainChildPaths.includes(previousPath)
+          ? previousPath.concat(path)
+          : path
+        : path;
+    });
+  }
+
+  /**
+   * Navega para o caminho pelo link do breadcrumb.
+   *
+   * @param path - Caminho da URL.
+   */
+  public navigateBreadcrumb(path: string) {
     this._router.navigate(['main', path]);
   }
+
+  /**
+   * Navega para o formulário de criação do tipo de dado sendo listado.
+   *
+   * O botão só aparece (portanto só navega) em componentes de listagem de dados.
+   *
+   * ex.: Projetos - `path = 'projects'`
+   *
+   * @param path - Caminho da URL
+   */
+  public navigateBreadcrumbNew(path: string) {
+    this._router.navigate(['main', path, 'form', 'create']);
+  }
+
+  /**
+   * Volta para a pagina anterior.
+   */
+  public goBack() {
+    history.back();
+  }
+
+  /**
+   * Avança para a próxima página.
+   */
+  public goForward() {
+    history.forward();
+  }
 }
-
-
-
-/* 
-- Redundancia do Home (ex: Home > Projetos > Novo Projeto)
-- Botão "Novo Projeto" vai pra direita (igual prototipo)
-- Icones de voltar/avançar
-*/

--- a/src/app/pages/main/main.component.html
+++ b/src/app/pages/main/main.component.html
@@ -13,7 +13,7 @@
       <div class="header-bar col-12">
         <app-header></app-header>
       </div>
-      <div class="breadcrumb-area col-12">
+      <div class="breadcrumb-area col-12 mb-5">
         <app-breadcrumb></app-breadcrumb>
       </div>
       <div class="main-content col overflow-y-hidden">

--- a/src/app/pages/projects/projects.component.html
+++ b/src/app/pages/projects/projects.component.html
@@ -1,9 +1,9 @@
 <div class="project-interaction mx-3">
   <div class="row g-0 d-flex justify-content-between align-items-center">
     <div class="col-6 col-sm-4 col-md-2 new-project-button">
-      <button class="btn btn-primary" (click)="redirectProjectForm('create')">
+      <!-- <button class="btn btn-primary" (click)="redirectProjectForm('create')">
         Novo Projeto
-      </button>
+      </button> -->
     </div>
     <div class="col-6 col-sm-4 col-md-2 search-input">
       <div class="input-group ms-auto ms-sm-0">

--- a/src/app/pages/projects/projects.component.ts
+++ b/src/app/pages/projects/projects.component.ts
@@ -100,13 +100,12 @@ export class ProjectsComponent implements OnInit, OnDestroy {
     };
   }
 
-  // Mudar de lugar daqui pro componente breadcrumb
-  redirectProjectForm(mode: string, projectId?: number) {
-    this._router.navigate(['form', mode], {
-      relativeTo: this._route,
-      queryParams: !!projectId ? { id: projectId } : undefined,
-    });
-  }
+  // redirectProjectForm(mode: string, projectId?: number) {
+  //   this._router.navigate(['form', mode], {
+  //     relativeTo: this._route,
+  //     queryParams: !!projectId ? { id: projectId } : undefined,
+  //   });
+  // }
 
   queryProject() {}
 

--- a/src/app/pipes/breadcrumbnavlink.pipe.ts
+++ b/src/app/pipes/breadcrumbnavlink.pipe.ts
@@ -1,30 +1,42 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+const enum breadCrumbTitles {
+  main = 'Home',
+  projects = 'Projetos',
+  projectscreate = 'Novo Projeto',
+  projectsedit = 'Editar Projeto',
+  projectsdetails = 'Visualizar Projeto',
+}
+
 @Pipe({
   name: 'breadcrumbnavlink',
   standalone: true,
 })
 export class BreadcrumbnavlinkPipe implements PipeTransform {
   transform(value: string, ...args: unknown[]): unknown {
-    if (value.includes('?')) {
-      value = value.slice(0, value.indexOf('?') + 1);
-    }
-    
     let transformedValue = '';
 
     switch (value) {
-      case 'home':
-        transformedValue = 'Home';
+      case 'main':
+        transformedValue = breadCrumbTitles.main;
         break;
+
       case 'projects':
-        transformedValue = 'Projetos';
+        transformedValue = breadCrumbTitles.projects;
         break;
-      case 'create':
-        transformedValue = 'Novo Projeto';
+
+      case 'projectscreate':
+        transformedValue = breadCrumbTitles.projectscreate;
         break;
-      case 'create?':
-        transformedValue = 'Editar Projeto';
+
+      case 'projectsedit':
+        transformedValue = breadCrumbTitles.projectsedit;
         break;
+
+      case 'projectsdetails':
+        transformedValue = breadCrumbTitles.projectsdetails;
+        break;
+        
 
       // Inserir demais casos:
       // case 'programs':


### PR DESCRIPTION
Alinhar navlinks e título da página com botão de home. Refazer a trilha de url do usuário (ex. Home > Projetos > Novo Projeto). Mover botão de cadastrar novo dado para a direita da página, alinhado com o breadcrumb á esquerda. Inserir ícones de navegação (Anterior/Avançar) á direita do botão de Novo.